### PR TITLE
SwiftUI support

### DIFF
--- a/OpenSourceController.xcodeproj/project.pbxproj
+++ b/OpenSourceController.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		76D7F24821BEB18A004B74CB /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D7F24321BEB18A004B74CB /* Array+Extensions.swift */; };
 		76D7F24921BEB18A004B74CB /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D7F24421BEB18A004B74CB /* UIView+Extensions.swift */; };
 		76EAA84F1E93EDCD009A41DA /* LicenceFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EAA84C1E93EDCD009A41DA /* LicenceFile.swift */; };
+		C415E47723E0B3AE002F960D /* OpenSourceViewController+UISwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = C415E47623E0B3AE002F960D /* OpenSourceViewController+UISwift.swift */; };
+		C415E47823E0B3AE002F960D /* OpenSourceViewController+UISwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = C415E47623E0B3AE002F960D /* OpenSourceViewController+UISwift.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +57,7 @@
 		76EAA84C1E93EDCD009A41DA /* LicenceFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LicenceFile.swift; path = Sources/Model/LicenceFile.swift; sourceTree = "<group>"; };
 		AD2FAA261CD0B6D800659CF4 /* OpenSourceController.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = OpenSourceController.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* OpenSourceControllerTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = OpenSourceControllerTests.plist; sourceTree = "<group>"; };
+		C415E47623E0B3AE002F960D /* OpenSourceViewController+UISwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OpenSourceViewController+UISwift.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +140,7 @@
 			isa = PBXGroup;
 			children = (
 				76229B7F2180ADA800A61697 /* OpenSourceController.swift */,
+				C415E47623E0B3AE002F960D /* OpenSourceViewController+UISwift.swift */,
 				76229B7E2180ADA800A61697 /* OpenSourceControllerConfig.swift */,
 				76229B7B2180AD8E00A61697 /* Loader */,
 				76229B702180AD7700A61697 /* Model */,
@@ -241,7 +245,7 @@
 					52D6D9851BEFF229002C0205 = {
 						CreatedOnToolsVersion = 7.1;
 						DevelopmentTeam = XEHEC9B46E;
-						LastSwiftMigration = "";
+						LastSwiftMigration = 1130;
 					};
 				};
 			};
@@ -295,6 +299,7 @@
 				76D7F24721BEB18A004B74CB /* UIViewController+Extensions.swift in Sources */,
 				76EAA84F1E93EDCD009A41DA /* LicenceFile.swift in Sources */,
 				76D7F24521BEB18A004B74CB /* UITableView+Extensions.swift in Sources */,
+				C415E47723E0B3AE002F960D /* OpenSourceViewController+UISwift.swift in Sources */,
 				769FD9D421871DEC00FB5A53 /* OpenSourceTableViewCell.swift in Sources */,
 				76D7F24821BEB18A004B74CB /* Array+Extensions.swift in Sources */,
 				76229B812180ADA800A61697 /* OpenSourceController.swift in Sources */,
@@ -308,6 +313,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C415E47823E0B3AE002F960D /* OpenSourceViewController+UISwift.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenSourceViewController+UISwift.swift
+++ b/OpenSourceViewController+UISwift.swift
@@ -1,0 +1,34 @@
+//
+//  OpenSourceViewController+UISwift.swift
+//  OpenSourceController
+//
+//  Created by Doron Katz on 1/28/20.
+//  Copyright © 2020 OpenSourceController. All rights reserved.
+//
+
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+extension OpenSourceViewController{
+    public struct OpenSourceView: UIViewControllerRepresentable {
+        
+        @available(iOS 13, *)
+        public func updateUIViewController(_ uiViewController: OpenSourceViewController, context: UIViewControllerRepresentableContext<OpenSourceView>) {
+            //
+        }
+        
+        @available(iOS 13, *)
+        public func makeUIViewController(context: UIViewControllerRepresentableContext<OpenSourceView>) -> OpenSourceViewController {
+            let openSourceVC = OpenSourceViewController(licences:
+                [LicenceFile(title: "MovieSwiftUI",
+                             url: "https://raw.githubusercontent.com/Dimillian/MovieSwiftUI/master/LICENSE"),
+                ],
+                                                        showCloseButton: true,
+                                                        configuration: OpenSourceControllerConfig(),
+                                                        licenceLoader: LicenceLoader())
+            return openSourceVC
+        }
+    }
+}
+

--- a/Sources/Controller/LicenceListViewController.swift
+++ b/Sources/Controller/LicenceListViewController.swift
@@ -6,9 +6,13 @@
 //  Copyright © 2018 OpenSourceController. All rights reserved.
 //
 
+#if !os(macOS)
 import UIKit
+#else
+import AppKit
+#endif
 
-final class LicenceListViewController: UITableViewController {
+open class LicenceListViewController: UITableViewController {
     
     // MARK: - Var
     
@@ -24,11 +28,11 @@ final class LicenceListViewController: UITableViewController {
         super.init(style: .plain)
     }
     
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         
         self.prepareTableView()
@@ -50,22 +54,22 @@ extension LicenceListViewController {
     
     // MARK: - Table View Data Source
     
-    override func numberOfSections(in tableView: UITableView) -> Int {
+    override open func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
     
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.downloadedLicence.count
     }
     
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: OpenSourceTableViewCell = tableView.dequeueReusableCell(for: indexPath)
         guard let licence = self.downloadedLicence.get(at: indexPath.row) else { return cell }
         cell.configure(licence: licence, config: self.config)
         return cell
     }
     
-    override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+    override open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
     }
 }

--- a/Sources/Controller/LoadingViewController.swift
+++ b/Sources/Controller/LoadingViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class LoadingViewController: UIViewController {
+open class LoadingViewController: UIViewController {
     
     // MARK: - Var
     
@@ -32,11 +32,11 @@ final class LoadingViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         
         self.view.backgroundColor = self.config.uiConfig.backgroundColor

--- a/Sources/Controller/OpenSourceTableViewCell.swift
+++ b/Sources/Controller/OpenSourceTableViewCell.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-final class OpenSourceTableViewCell: UITableViewCell, Reusable {
+open class OpenSourceTableViewCell: UITableViewCell, Reusable {
 
     // MARK: - Lifecycle
 
@@ -15,7 +15,7 @@ final class OpenSourceTableViewCell: UITableViewCell, Reusable {
         self.prepareCellComponent()
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
 

--- a/Sources/Controller/OpenSourceViewController.swift
+++ b/Sources/Controller/OpenSourceViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-final class OpenSourceViewController: UIViewController {
+open class OpenSourceViewController: UIViewController {
     
     // MARK: - Var
     
@@ -42,11 +42,11 @@ final class OpenSourceViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         
         self.title = self.config.title

--- a/Sources/Controller/OpenSourceViewController.swift
+++ b/Sources/Controller/OpenSourceViewController.swift
@@ -30,7 +30,7 @@ open class OpenSourceViewController: UIViewController {
     
     // MARK: - Lifecyle
     
-    init(licences: [LicenceFile],
+    public init(licences: [LicenceFile],
          showCloseButton: Bool,
          configuration: OpenSourceControllerConfig,
          licenceLoader: LicenceLoader) {

--- a/Sources/Loader/HTTPDataLoader.swift
+++ b/Sources/Loader/HTTPDataLoader.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-final class HTTPDataLoader {
+open class HTTPDataLoader {
     func loadData(fromUrl url: String, completion: @escaping (Data?) -> Void) {
         if let url = URL(string: url) {
             let task = URLSession.shared.dataTask(with: url) { (data, _, error) in

--- a/Sources/Loader/LicenceLoader.swift
+++ b/Sources/Loader/LicenceLoader.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-final class LicenceLoader {
+open class LicenceLoader {
 
     /// Download every licence 
     ///
@@ -31,5 +31,7 @@ final class LicenceLoader {
         licenceGroupe.notify(queue: .main) {
             completion()
         }
+    }
+    public init() {
     }
 }

--- a/Sources/Model/LicenceFile.swift
+++ b/Sources/Model/LicenceFile.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-public final class LicenceFile {
+open class LicenceFile {
 
     // MARK- Var 
 

--- a/Sources/OpenSourceController.swift
+++ b/Sources/OpenSourceController.swift
@@ -5,6 +5,9 @@
 //  Created by Florian Gabach on 05/02/2017.
 
 import UIKit
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
 
 open class OpenSourceController: NSObject { 
 
@@ -43,3 +46,4 @@ open class OpenSourceController: NSObject {
         navigationController.pushViewController(licenceController, animated: true)
     }
 }
+

--- a/Sources/OpenSourceControllerConfig.swift
+++ b/Sources/OpenSourceControllerConfig.swift
@@ -35,5 +35,8 @@ public struct OpenSourceControllerConfig {
     public var verbose: Bool = false
 
     /// UI-specific configuration.
+    
+    public init() {
+    }
     public var uiConfig = UIConfig()
 }

--- a/Sources/Utils/UITableView+Extensions.swift
+++ b/Sources/Utils/UITableView+Extensions.swift
@@ -9,12 +9,12 @@
 import UIKit
 
 extension UITableView { 
-    final func register<T: UITableViewCell>(cellType: T.Type)
+    open func register<T: UITableViewCell>(cellType: T.Type)
         where T: Reusable {
             self.register(cellType.self, forCellReuseIdentifier: cellType.reuseIdentifier)
     }
     
-    final func dequeueReusableCell<T: UITableViewCell>(for indexPath: IndexPath, cellType: T.Type = T.self) -> T
+    open func dequeueReusableCell<T: UITableViewCell>(for indexPath: IndexPath, cellType: T.Type = T.self) -> T
         where T: Reusable {
             guard let cell = self.dequeueReusableCell(withIdentifier: cellType.reuseIdentifier, for: indexPath) as? T else {
                 fatalError(


### PR DESCRIPTION
This is to support SwiftUI, by referencing a struct wrapped ViewController. On client-side, you still need to implement `UIViewControllerRepresentable` as denoted in https://www.hackingwithswift.com/books/ios-swiftui/wrapping-a-uiviewcontroller-in-a-swiftui-view.